### PR TITLE
Add the outsidersCanSpawn status flag to the towns endpoint.

### DIFF
--- a/docs/towns.md
+++ b/docs/towns.md
@@ -58,7 +58,8 @@ Look up the specified town names to get town data, for example https://api.earth
       "isRuined": false, // True if the town is ruined
       "isForSale": false, // True if the town is for sale
       "hasNation": true, // True if the town has a nation
-      "hasOverclaimShield": false // True if the town currently has an overclaim shield
+      "hasOverclaimShield": false, // True if the town currently has an overclaim shield
+      "outsidersCanSpawn": false, // True if the town allows outsiders to teleport.
     },
     "stats": {
       "numTownBlocks": 473, // The total number of town blocks the town has

--- a/src/main/java/net/earthmc/emcapi/endpoint/TownsEndpoint.java
+++ b/src/main/java/net/earthmc/emcapi/endpoint/TownsEndpoint.java
@@ -37,7 +37,6 @@ public class TownsEndpoint {
 
         JsonObject statusObject = new JsonObject();
         statusObject.addProperty("isPublic", town.isPublic());
-        statusObject.addProperty("outsidersCanSpawn", TownMetadataManager.getOutsidersCanSpawn(town));
         statusObject.addProperty("isOpen", town.isOpen());
         statusObject.addProperty("isNeutral", town.isNeutral());
         statusObject.addProperty("isCapital", town.isCapital());
@@ -46,6 +45,7 @@ public class TownsEndpoint {
         statusObject.addProperty("isForSale", town.isForSale());
         statusObject.addProperty("hasNation", town.hasNation());
         statusObject.addProperty("hasOverclaimShield", TownMetadataManager.hasOverclaimShield(town));
+        statusObject.addProperty("outsidersCanSpawn", TownMetadataManager.getOutsidersCanSpawn(town));
         townObject.add("status", statusObject);
 
         JsonObject statsObject = new JsonObject();

--- a/src/main/java/net/earthmc/emcapi/endpoint/TownsEndpoint.java
+++ b/src/main/java/net/earthmc/emcapi/endpoint/TownsEndpoint.java
@@ -37,6 +37,7 @@ public class TownsEndpoint {
 
         JsonObject statusObject = new JsonObject();
         statusObject.addProperty("isPublic", town.isPublic());
+        statusObject.addProperty("outsidersCanSpawn", TownMetadataManager.getOutsidersCanSpawn(town));
         statusObject.addProperty("isOpen", town.isOpen());
         statusObject.addProperty("isNeutral", town.isNeutral());
         statusObject.addProperty("isCapital", town.isCapital());

--- a/src/main/java/net/earthmc/emcapi/manager/TownMetadataManager.java
+++ b/src/main/java/net/earthmc/emcapi/manager/TownMetadataManager.java
@@ -14,6 +14,14 @@ public class TownMetadataManager {
         return bdf.getValue();
     }
 
+    public static boolean getOutsidersCanSpawn(Town town) {
+        BooleanDataField bdf = (BooleanDataField) town.getMetadata("bspawn_canoutsidersspawn");
+        if (bdf == null)
+            return false;
+
+        return bdf.getValue();
+    }
+
     public static String getWikiURL(Town town) {
         StringDataField sdf = (StringDataField) town.getMetadata("wiki_url");
         if (sdf == null)


### PR DESCRIPTION
Adds a new `outsidersCanSpawn` flag to the town object under `status` by fetching `bspawn` metadata.