### PR TITLE
Some qol in ServerEndpoint.

### DIFF
--- a/src/main/java/net/earthmc/emcapi/endpoint/ServerEndpoint.java
+++ b/src/main/java/net/earthmc/emcapi/endpoint/ServerEndpoint.java
@@ -4,13 +4,16 @@ import com.google.gson.JsonObject;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownySettings;
 import io.minimum.minecraft.superbvote.SuperbVote;
+import io.minimum.minecraft.superbvote.votes.VoteParty;
 import net.earthmc.emcapi.object.endpoint.GetEndpoint;
 import net.earthmc.emcapi.util.EndpointUtils;
+import au.lupine.quarters.object.entity.Quarter;
 import au.lupine.quarters.api.manager.QuarterManager;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 
 import java.time.LocalTime;
+import java.util.List;
 
 public class ServerEndpoint extends GetEndpoint {
 
@@ -52,13 +55,13 @@ public class ServerEndpoint extends GetEndpoint {
         statsObject.addProperty("numTownBlocks", townyAPI.getTownBlocks().size());
         statsObject.addProperty("numNations", townyAPI.getNations().size());
 
-        var quarters = quarterManager.getAllQuarters();
+        List<Quarter> quarters = quarterManager.getAllQuarters();
         statsObject.addProperty("numQuarters", quarters.size());
-        statsObject.addProperty("numCuboids", quarters.parallelStream().mapToInt(quarter -> quarter.getCuboids().size()).sum());
+        statsObject.addProperty("numCuboids", quarters.parallelStream().mapToInt(q -> q.getCuboids().size()).sum());
 
         serverObject.add("stats", statsObject);
 
-        var voteParty = SuperbVote.getPlugin().getVoteParty();
+        VoteParty voteParty = SuperbVote.getPlugin().getVoteParty();
         int target = voteParty.votesNeeded();
         int currentVotes = voteParty.getCurrentVotes();
 

--- a/src/main/java/net/earthmc/emcapi/endpoint/ServerEndpoint.java
+++ b/src/main/java/net/earthmc/emcapi/endpoint/ServerEndpoint.java
@@ -37,7 +37,7 @@ public class ServerEndpoint extends GetEndpoint {
 
         JsonObject statusObject = new JsonObject();
         statusObject.addProperty("hasStorm", overworld.hasStorm());
-        statusObject.addProperty("isThundering", overworld.hasStorm());
+        statusObject.addProperty("isThundering", overworld.isThundering());
         serverObject.add("status", statusObject);
 
         JsonObject statsObject = new JsonObject();
@@ -51,12 +51,16 @@ public class ServerEndpoint extends GetEndpoint {
         statsObject.addProperty("numTowns", townyAPI.getTowns().size());
         statsObject.addProperty("numTownBlocks", townyAPI.getTownBlocks().size());
         statsObject.addProperty("numNations", townyAPI.getNations().size());
-        statsObject.addProperty("numQuarters", quarterManager.getAllQuarters().size());
-        statsObject.addProperty("numCuboids", quarterManager.getAllQuarters().stream().mapToInt(quarter -> quarter.getCuboids().size()).sum());
+
+        var quarters = quarterManager.getAllQuarters();
+        statsObject.addProperty("numQuarters", quarters.size());
+        statsObject.addProperty("numCuboids", quarters.parallelStream().mapToInt(quarter -> quarter.getCuboids().size()).sum());
+
         serverObject.add("stats", statsObject);
 
-        int target = SuperbVote.getPlugin().getVoteParty().votesNeeded();
-        int currentVotes = SuperbVote.getPlugin().getVoteParty().getCurrentVotes();
+        var voteParty = SuperbVote.getPlugin().getVoteParty();
+        int target = voteParty.votesNeeded();
+        int currentVotes = voteParty.getCurrentVotes();
 
         JsonObject votePartyObject = new JsonObject();
         votePartyObject.addProperty("target", target);


### PR DESCRIPTION
**Help perf for both server and client.**
- Avoid getting all quarters and the vote party twice unnecessarily.
- Calculate `numCuboids` in parallel bc why not.

**General**
- Fix `isThundering` property using the value of `hasStorm` - while they will usually be both true at the same time, it's probably better to adhere to the Bukkit convention just in-case.