### PR TITLE
Simplify `PostEndpoint.java`

### DIFF
--- a/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
+++ b/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
@@ -13,15 +13,11 @@ public abstract class PostEndpoint<T> {
         int numLoops = Math.min(EMCAPI.instance.getConfig().getInt("behaviour.max_lookup_size"), queryArray.size());
         for (int i = 0; i < numLoops; i++) {
             JsonElement element = queryArray.get(i);
+
             T object = getObjectOrNull(element);
-
-            JsonElement innerObject;
-            if (object == null) {
-                continue;
-            } else {
-                innerObject = getTemplateJsonElement(object, template);
-            }
-
+            if (object == null) continue;
+            
+            JsonElement innerObject = getTemplateJsonElement(object, template);
             jsonArray.add(innerObject);
         }
 

--- a/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
+++ b/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
@@ -36,21 +36,25 @@ public abstract class PostEndpoint<T> {
 
     public JsonElement getTemplateJsonElement(T object, JsonObject template) {
         JsonElement fullJson = getJsonElement(object);
-
-        if (!(fullJson instanceof JsonObject) || template == null || template.entrySet().isEmpty()) {
-            return fullJson;
-        }
+        
+        // Just return the full element in both cases.
+        if (!(fullJson instanceof JsonObject)) return fullJson;
+        if (!templateMissingOrEmpty(template)) return fullJson;
 
         JsonObject fullJsonObject = fullJson.getAsJsonObject();
         JsonObject filteredJson = new JsonObject();
-
-        for (Map.Entry<String, JsonElement> entry : template.entrySet()) {
-            String key = entry.getKey();
-            if (entry.getValue().getAsBoolean() && fullJsonObject.has(key)) {
-                filteredJson.add(key, fullJsonObject.get(key));
+        
+        template.asMap().forEach((key, value) -> {
+            JsonElement el = fullJsonObject.get(key);
+            if (value.getAsBoolean() && el != null) {
+                filteredJson.add(key, el);
             }
-        }
+        });
 
         return filteredJson;
+    }
+    
+    public final boolean templateMissingOrEmpty(JsonObject template) {
+        return template == null || template.entrySet().isEmpty();
     }
 }

--- a/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
+++ b/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
@@ -53,6 +53,6 @@ public abstract class PostEndpoint<T> {
     }
     
     public final boolean templateMissingOrEmpty(JsonObject template) {
-        return template == null || template.entrySet().isEmpty();
+        return template == null || template.asMap().isEmpty();
     }
 }

--- a/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
+++ b/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
@@ -35,9 +35,9 @@ public abstract class PostEndpoint<T> {
     public JsonElement getTemplateJsonElement(T object, JsonObject template) {
         JsonElement fullJson = getJsonElement(object);
         
-        // Just return the full element in both cases.
-        if (!(fullJson instanceof JsonObject)) return fullJson;
-        if (!templateMissingOrEmpty(template)) return fullJson;
+        // Just return the full, unaltered element in both cases.
+        if (!fullJson.isJsonObject()) return fullJson;
+        if (templateMissingOrEmpty(template)) return fullJson;
 
         JsonObject fullJsonObject = fullJson.getAsJsonObject();
         JsonObject filteredJson = new JsonObject();

--- a/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
+++ b/src/main/java/net/earthmc/emcapi/object/endpoint/PostEndpoint.java
@@ -5,8 +5,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.earthmc.emcapi.EMCAPI;
 
-import java.util.Map;
-
 public abstract class PostEndpoint<T> {
 
     public String lookup(JsonArray queryArray, JsonObject template) {


### PR DESCRIPTION
This PR aims to improve readability and reduce complexity of certain areas in this file. Basically qol :P

### lookup
- Removed a redundant else block within the `lookup` method since `continue` should handle this.

### getTemplateJsonElement
- Changed the loop over `template.entrySet()` so it uses the underlying map instead of an unnecessary creation of an `EntrySet`.
- Removed the extra `.has(key)` check since `.get(key)` should return null anyway if it isn't found. 
- Factored out the long condition check into an aptly named method for easier understanding at first glance. This method also uses `asMap()` instead of `entrySet()` since `isEmpty()` is available on that also.

Oh and I preferred `fullJson.isJsonObject()` over an ugly `instanceof` check because it does the same thing.