### PR TITLE
Return most 10 recent transactions instead of oldest

### DIFF
--- a/src/main/java/net/earthmc/emcapi/util/EndpointUtils.java
+++ b/src/main/java/net/earthmc/emcapi/util/EndpointUtils.java
@@ -240,7 +240,8 @@ public class EndpointUtils {
         if (history.isEmpty()) {
             return json;
         }
-        for (int i = 0; i < Math.min(10, history.size()); i++) {
+        int start = Math.max(0, history.size() - 10);
+        for (int i = history.size() - 1; i >= start; i--) {
             BankTransaction transaction = history.get(i);
             json.add(getBankTransactionObject(transaction));
         }


### PR DESCRIPTION
Bug: Currently, no new transactions are visible via either the nations or towns endpoints after the first 10 transactions. This persists until a server restart.

Fix: Loop over the 10 most recent transactions rather than the 10 oldest, as seen with `/n bankhistory` default behavior