### PR TITLE
Add authorisation functionality to shop SSE events

### DIFF
--- a/src/main/java/net/earthmc/emcapi/manager/Authorisation.java
+++ b/src/main/java/net/earthmc/emcapi/manager/Authorisation.java
@@ -30,6 +30,10 @@ public class Authorisation {
         return authMap.containsKey(owner) && authMap.get(owner).authorize(type, target);
     }
 
+    public AuthSettings getAuthSettings(UUID owner) {
+        return authMap.get(owner) // This is safe because ConcurrentHashMap will return null if there authMap.containsKey(owner) is false
+    }
+
     public void saveAuthSettings(UUID uuid) {
         AuthSettings settings = authMap.get(uuid);
         if (settings == null) {

--- a/src/main/java/net/earthmc/emcapi/manager/Authorisation.java
+++ b/src/main/java/net/earthmc/emcapi/manager/Authorisation.java
@@ -31,7 +31,7 @@ public class Authorisation {
     }
 
     public AuthSettings getAuthSettings(UUID owner) {
-        return authMap.get(owner) // This is safe because ConcurrentHashMap will return null if there authMap.containsKey(owner) is false
+        return authMap.get(owner); // This is safe because ConcurrentHashMap will return null if there authMap.containsKey(owner) is false
     }
 
     public void saveAuthSettings(UUID uuid) {

--- a/src/main/java/net/earthmc/emcapi/object/optout/AuthSettings.java
+++ b/src/main/java/net/earthmc/emcapi/object/optout/AuthSettings.java
@@ -64,6 +64,10 @@ public record AuthSettings(Map<Type, Set<UUID>> authorised) {
         return authorised.isEmpty();
     }
 
+    public Set<UUID> getAuthorizedForType(Type type) {
+        return authorised.getOrDefault(type, Set.of())
+    }
+
     public String getStringForType(Type type) {
         return authorised.containsKey(type) ? authorised.get(type).stream().map(UUID::toString).collect(Collectors.joining(",")) : "";
     }

--- a/src/main/java/net/earthmc/emcapi/object/optout/AuthSettings.java
+++ b/src/main/java/net/earthmc/emcapi/object/optout/AuthSettings.java
@@ -65,7 +65,7 @@ public record AuthSettings(Map<Type, Set<UUID>> authorised) {
     }
 
     public Set<UUID> getAuthorizedForType(Type type) {
-        return authorised.getOrDefault(type, Set.of())
+        return authorised.getOrDefault(type, Set.of());
     }
 
     public String getStringForType(Type type) {

--- a/src/main/java/net/earthmc/emcapi/sse/SSEManager.java
+++ b/src/main/java/net/earthmc/emcapi/sse/SSEManager.java
@@ -5,6 +5,8 @@ import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 import io.javalin.http.sse.SseClient;
 import net.earthmc.emcapi.EMCAPI;
+import net.earthmc.emcapi.object.optout.AuthSettings;
+import net.earthmc.emcapi.manager.Authorisation;
 import net.earthmc.emcapi.manager.KeyManager;
 import net.earthmc.emcapi.util.JSONUtil;
 import org.jetbrains.annotations.Nullable;
@@ -165,6 +167,23 @@ public class SSEManager {
                 clientData.client.sendEvent(event, message);
             }
         });
+    }
+
+    public void sendAuthorizedEvent(String event, JsonObject data, UUID targetPlayerId, AuthSettings.Type type) {
+        sendEvent(event, data, targetPlayerId);
+
+        Authorisation auth = plugin.getAuth();
+
+        var settings = auth.getAuthSettings(targetPlayerId);
+        if (settings == null) {
+            return;
+        }
+
+        var authorizedUUIDs = settings.getAuthorizedForType(type);
+
+        for (UUID uuid: authorizedUUIDs) {
+            sendEvent(event, data, uuid);
+        }
     }
 
     public static void deleteKey(String key) {

--- a/src/main/java/net/earthmc/emcapi/sse/listeners/ShopSSEListener.java
+++ b/src/main/java/net/earthmc/emcapi/sse/listeners/ShopSSEListener.java
@@ -9,6 +9,7 @@ import com.ghostchu.quickshop.api.shop.Shop;
 import com.google.gson.JsonObject;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
+import net.earthmc.emcapi.object.optout.AuthSettings;
 import net.earthmc.emcapi.sse.SSEManager;
 import net.earthmc.emcapi.util.EndpointUtils;
 import org.bukkit.event.EventHandler;
@@ -37,10 +38,10 @@ public class ShopSSEListener extends AbstractSSEListener {
         saleMessage.addProperty("amount", event.getAmount());
         if (isSelling) {
             saleMessage.addProperty("buyer", purchaser);
-            sse.sendEvent("ShopSoldItem", saleMessage, owner);
+            sse.sendAuthorizedEvent("ShopSoldItem", saleMessage, owner, AuthSettings.Type.SHOP_SSE)
         } else {
             saleMessage.addProperty("seller", purchaser);
-            sse.sendEvent("ShopBoughtItem", saleMessage, owner);
+            sse.sendAuthorizedEvent("ShopBoughtItem", saleMessage, owner, AuthSettings.Type.SHOP_SSE)
         }
 
         checkOwnerBalance(owner);
@@ -65,7 +66,7 @@ public class ShopSSEListener extends AbstractSSEListener {
 
         JsonObject message = new JsonObject();
         message.add("shop", EndpointUtils.getShopObject(shop));
-        sse.sendEvent("ShopCreated", message, owner);
+        sse.sendAuthorizedEvent("ShopCreated", message, owner, AuthSettings.Type.SHOP_SSE)
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -82,14 +83,14 @@ public class ShopSSEListener extends AbstractSSEListener {
 
         JsonObject message = new JsonObject();
         message.add("shop", EndpointUtils.getShopObject(shop));
-        sse.sendEvent("ShopDeleted", message, owner);
+        sse.sendAuthorizedEvent("ShopDeleted", message, owner, AuthSettings.Type.SHOP_SSE)
     }
 
     private void checkOwnerBalance(UUID owner) {
         Resident res = TownyAPI.getInstance().getResident(owner);
         if (res == null || res.getAccount().getHoldingBalance() > 0) return;
 
-        sse.sendEvent("ShopOutOfGold", new JsonObject(), owner);
+        sse.sendAuthorizedEvent("ShopOutOfGold", new JsonObject(), owner, AuthSettings.Type.SHOP_SSE)
     }
 
     private void checkShopOut(Shop shop) {
@@ -100,7 +101,7 @@ public class ShopSSEListener extends AbstractSSEListener {
         JsonObject alertMessage = new JsonObject();
         alertMessage.addProperty("action", isSelling ? "out_of_stock" : "out_of_space");
         alertMessage.add("shop", EndpointUtils.getShopObject(shop));
-        sse.sendEvent("ShopOutOf" + (isSelling ? "Stock" : "Space"), alertMessage, shop.getOwner().getUniqueId());
+        sse.sendAuthorizedEvent("ShopOutOf" + (isSelling ? "Stock" : "Space"), alertMessage, shop.getOwner(), AuthSettings.Type.SHOP_SSE)
     }
 
     private String getPlayerName(QUser user) {

--- a/src/main/java/net/earthmc/emcapi/sse/listeners/ShopSSEListener.java
+++ b/src/main/java/net/earthmc/emcapi/sse/listeners/ShopSSEListener.java
@@ -38,10 +38,10 @@ public class ShopSSEListener extends AbstractSSEListener {
         saleMessage.addProperty("amount", event.getAmount());
         if (isSelling) {
             saleMessage.addProperty("buyer", purchaser);
-            sse.sendAuthorizedEvent("ShopSoldItem", saleMessage, owner, AuthSettings.Type.SHOP_SSE)
+            sse.sendAuthorizedEvent("ShopSoldItem", saleMessage, owner, AuthSettings.Type.SHOP_SSE);
         } else {
             saleMessage.addProperty("seller", purchaser);
-            sse.sendAuthorizedEvent("ShopBoughtItem", saleMessage, owner, AuthSettings.Type.SHOP_SSE)
+            sse.sendAuthorizedEvent("ShopBoughtItem", saleMessage, owner, AuthSettings.Type.SHOP_SSE);
         }
 
         checkOwnerBalance(owner);
@@ -66,7 +66,7 @@ public class ShopSSEListener extends AbstractSSEListener {
 
         JsonObject message = new JsonObject();
         message.add("shop", EndpointUtils.getShopObject(shop));
-        sse.sendAuthorizedEvent("ShopCreated", message, owner, AuthSettings.Type.SHOP_SSE)
+        sse.sendAuthorizedEvent("ShopCreated", message, owner, AuthSettings.Type.SHOP_SSE);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -83,14 +83,14 @@ public class ShopSSEListener extends AbstractSSEListener {
 
         JsonObject message = new JsonObject();
         message.add("shop", EndpointUtils.getShopObject(shop));
-        sse.sendAuthorizedEvent("ShopDeleted", message, owner, AuthSettings.Type.SHOP_SSE)
+        sse.sendAuthorizedEvent("ShopDeleted", message, owner, AuthSettings.Type.SHOP_SSE);
     }
 
     private void checkOwnerBalance(UUID owner) {
         Resident res = TownyAPI.getInstance().getResident(owner);
         if (res == null || res.getAccount().getHoldingBalance() > 0) return;
 
-        sse.sendAuthorizedEvent("ShopOutOfGold", new JsonObject(), owner, AuthSettings.Type.SHOP_SSE)
+        sse.sendAuthorizedEvent("ShopOutOfGold", new JsonObject(), owner, AuthSettings.Type.SHOP_SSE);
     }
 
     private void checkShopOut(Shop shop) {
@@ -101,7 +101,7 @@ public class ShopSSEListener extends AbstractSSEListener {
         JsonObject alertMessage = new JsonObject();
         alertMessage.addProperty("action", isSelling ? "out_of_stock" : "out_of_space");
         alertMessage.add("shop", EndpointUtils.getShopObject(shop));
-        sse.sendAuthorizedEvent("ShopOutOf" + (isSelling ? "Stock" : "Space"), alertMessage, shop.getOwner(), AuthSettings.Type.SHOP_SSE)
+        sse.sendAuthorizedEvent("ShopOutOf" + (isSelling ? "Stock" : "Space"), alertMessage, shop.getOwner(), AuthSettings.Type.SHOP_SSE);
     }
 
     private String getPlayerName(QUser user) {


### PR DESCRIPTION
getAuthSettings in Authorisation.java will return the AuthSettings of the given player. This may be null, so deal with that accordingly.

getAuthorizedForType in AuthSettings will return the Set<UUID> that is everyone who has been authorized by the given player for the given type.

sendAuthorizedEvent will sendEvent to the given player, as well as all players who are authorized in the given type. I put this here so that it can be reused for towny events in the future.